### PR TITLE
API Warn if use non-private configs (declared as config in parent class)

### DIFF
--- a/tests/PrivateStaticTransformerTest/ClassK.php
+++ b/tests/PrivateStaticTransformerTest/ClassK.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SilverStripe\Config\Tests\PrivateStaticTransformerTest;
+
+class ClassK
+{
+    private static $option = 'value';
+}

--- a/tests/PrivateStaticTransformerTest/ClassL.php
+++ b/tests/PrivateStaticTransformerTest/ClassL.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SilverStripe\Config\Tests\PrivateStaticTransformerTest;
+
+class ClassL extends CLassK
+{
+    public static $option = 'something';
+}

--- a/tests/Transformer/PrivateStaticTransformerTest.php
+++ b/tests/Transformer/PrivateStaticTransformerTest.php
@@ -2,8 +2,11 @@
 
 namespace SilverStripe\Config\Tests\Transformer;
 
+use LogicException;
 use SilverStripe\Config\Tests\PrivateStaticTransformerTest\ClassA;
 use SilverStripe\Config\Tests\PrivateStaticTransformerTest\ClassB;
+use SilverStripe\Config\Tests\PrivateStaticTransformerTest\ClassK;
+use SilverStripe\Config\Tests\PrivateStaticTransformerTest\ClassL;
 use SilverStripe\Config\Transformer\PrivateStaticTransformer;
 use SilverStripe\Config\Collections\MemoryConfigCollection;
 use PHPUnit\Framework\TestCase;
@@ -91,4 +94,20 @@ class PrivateStaticTransformerTest extends TestCase
         $this->assertFalse($collection->exists($class));
     }
 
+
+    public function testInvalidConfigError()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            ClassL::class . '::option is not private but overrides a private static '
+            . 'config in parent class ' . ClassK::class
+        );
+        $classes = [
+            ClassK::class,
+            ClassL::class,
+        ];
+        $collection = new MemoryConfigCollection;
+        $transformer = new PrivateStaticTransformer($classes, $collection);
+        $collection->transform([$transformer]);
+    }
 }


### PR DESCRIPTION
And by warn, I mean error.

Fixes https://github.com/silverstripe/silverstripe-framework/issues/7113