### PR TITLE
API Throw user warning when using Config::inst()->update()

### DIFF
--- a/src/Collections/CachedConfigCollection.php
+++ b/src/Collections/CachedConfigCollection.php
@@ -204,4 +204,15 @@ class CachedConfigCollection implements ConfigCollectionInterface
             "Please apply middleware to collection factory via setCollectionCreator()"
         );
     }
+
+    /**
+     * @deprecated 4.0...5.0 Please use YAML configuration, ::modify()->set() or ::modify()->merge()
+     * @throws BadMethodCallException
+     */
+    public function update($class, $name, $value)
+    {
+        throw new BadMethodCallException(
+            'Config::inst()->update() is deprecated. Please use YAML configuration, Config::modify()->merge() or ->set()'
+        );
+    }
 }


### PR DESCRIPTION
Implements a user warning when using `Config::inst()->update` (via the SilverStripe framework) and suggests the non-deprecated alternative.

Resolves https://github.com/silverstripe/silverstripe-framework/issues/6803