### PR TITLE
BUG Fix issue with non-associative rule conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php: 5.6
 
 before_script:
+  - composer validate
   - composer install --prefer-dist
 
 script:

--- a/src/Collections/MemoryConfigCollection.php
+++ b/src/Collections/MemoryConfigCollection.php
@@ -146,7 +146,9 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface, Serial
 
         // Build middleware
         $result = $this->callMiddleware(
-            $class, $excludeMiddleware, function ($class, $excludeMiddleware) {
+            $class,
+            $excludeMiddleware,
+            function ($class, $excludeMiddleware) {
                 $class = strtolower($class);
                 return isset($this->config[$class]) ? $this->config[$class] : [];
             }
@@ -260,7 +262,6 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface, Serial
             $this->middlewares,
             $this->callCache
         ]);
-
     }
 
     public function unserialize($serialized)
@@ -298,7 +299,8 @@ class MemoryConfigCollection implements MutableConfigCollectionInterface, Serial
             }
 
             array_unshift(
-                $this->history[$class], [
+                $this->history[$class],
+                [
                 'value' => $this->config[$class],
                 'metadata' => $this->metadata[$class]
                 ]

--- a/src/Transformer/PrivateStaticTransformer.php
+++ b/src/Transformer/PrivateStaticTransformer.php
@@ -139,7 +139,8 @@ class PrivateStaticTransformer implements TransformerInterface
      * @param mixed $input
      * @return true
      */
-    protected function isConfigValue($input) {
+    protected function isConfigValue($input)
+    {
         if (is_object($input) || is_resource($input)) {
             return false;
         }

--- a/tests/Collections/CachedConfigCollectionTest.php
+++ b/tests/Collections/CachedConfigCollectionTest.php
@@ -52,7 +52,7 @@ class CachedConfigCollectionTest extends TestCase
             ->shouldBeCalledTimes(1);
 
         $collection = new CachedConfigCollection();
-        $collection->setCollectionCreator(function(){
+        $collection->setCollectionCreator(function () {
             $this->fail("Invalid cache miss");
         });
         $collection->setCache($mockCache->reveal());
@@ -87,7 +87,7 @@ class CachedConfigCollectionTest extends TestCase
             ->shouldBeCalledTimes(2);
 
         $collection = new CachedConfigCollection();
-        $collection->setCollectionCreator(function() use ($mockCollection) {
+        $collection->setCollectionCreator(function () use ($mockCollection) {
             return $mockCollection->reveal();
         });
         $collection->setCache($mockCache->reveal());
@@ -116,7 +116,7 @@ class CachedConfigCollectionTest extends TestCase
         // Build new config
         $collection = new CachedConfigCollection();
         $collection->setCache($mockCache->reveal());
-        $collection->setCollectionCreator(function() use ($collection) {
+        $collection->setCollectionCreator(function () use ($collection) {
             $collection->getCollection();
         });
         $collection->getCollection();

--- a/tests/Collections/MemoryConfigCollectionTest.php
+++ b/tests/Collections/MemoryConfigCollectionTest.php
@@ -89,5 +89,4 @@ class MemoryConfigCollectionTest extends TestCase
             $collection->getHistory()
         );
     }
-
 }

--- a/tests/Transformer/PrivateStaticTransformerTest.php
+++ b/tests/Transformer/PrivateStaticTransformerTest.php
@@ -84,7 +84,7 @@ class PrivateStaticTransformerTest extends TestCase
     public function testInvalidClass()
     {
         $class = 'SomeNonExistentClass';
-        if(class_exists($class)) {
+        if (class_exists($class)) {
             $this->markTestSkipped($class . ' exists but the test expects it not to.');
         }
 


### PR DESCRIPTION
BUG Fix issue with conjunction of rules; ’only’ should be and, ‘except’ should be or
BUG Fix PSR-2 formatting

See https://github.com/silverstripe/silverstripe-assets/issues/43 for parent story

@micmania1 I'd appreciate some feedback:

I discovered the bug with the below rules:

```yaml
Name: silverstripes3-assetscore
Only:
  envvarset:
    - AWS_REGION
    - AWS_BUCKET_NAME
```

My envarset was failing because it was checking `getenv(0) === 'AWS_REGION'` when it should be `getenv('AWS_REGION') !== false`.

Also, multiple "Except" rules wouldn't correctly exclude if only one of the except conditions was true; This issue existed not only for multiple except rules, but a single except rule with multiple values.

I've consolidated the logic for conjunction into a single method, and added tests to demonstrate the fix.