### PR TITLE
BUG Fix parameter order

### DIFF
--- a/src/Transformer/YamlTransformer.php
+++ b/src/Transformer/YamlTransformer.php
@@ -436,7 +436,7 @@ class YamlTransformer implements TransformerInterface
         }
 
         // Replace all `*` with `[^\.][a-zA-Z0-9\-_\/\.]+`, and quote other characters
-        $patternRegExp = '%^'.implode(
+        $patternRegExp = '%(^|[/\\\\])'.implode(
             '[^\.][a-zA-Z0-9\-_\/\.]+',
             array_map(
                 function ($part) {

--- a/src/Transformer/YamlTransformer.php
+++ b/src/Transformer/YamlTransformer.php
@@ -428,7 +428,7 @@ class YamlTransformer implements TransformerInterface
         // and check their filename and maybe their document name, depending on the pattern.
         // We don't want to do any pattern matching after the first hash as the document name
         // is assumed to follow it.
-        $firstHash = strpos('#', $pattern);
+        $firstHash = strpos($pattern, '#');
         $documentName = false;
         if ($firstHash !== false) {
             $documentName = substr($pattern, $firstHash + 1);
@@ -445,6 +445,7 @@ class YamlTransformer implements TransformerInterface
                 explode('*', $pattern)
             )
         ).'%';
+
         $matchedDocuments = [];
         foreach ($documents as $document) {
             // Ensure filename is relative

--- a/tests/Transformer/YamlTransformerTest.php
+++ b/tests/Transformer/YamlTransformerTest.php
@@ -273,7 +273,7 @@ YAML;
         $content = <<<'YAML'
 ---
 name: test2
-before: 'test/*'
+before: 'test/*#test'
 ---
 test: 'should not overwrite'
 YAML;
@@ -289,6 +289,7 @@ YAML;
 
         $this->assertEquals('test', $collection->get('test'));
 
+        // this one is kind of moot because if the matching fails, it'll go after anyway...
         $content = <<<'YAML'
 ---
 name: test3


### PR DESCRIPTION
Found the parameters given to `strpos()` was in the wrong order.

Fixes https://github.com/silverstripe/silverstripe-config/issues/14 to an extent
The pattern matching is filepath so `framework/_config/routes` would work, but `framework/routes` will not.

@tractorcow @micmania1 what do you think, we could add a bit of logic to remove `/_config/` from the filepath?