### PR TITLE
BUG Remove composer extra composer key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "mikey179/vfsStream": "^1.6",
         "phpspec/prophecy": "^1.0"
     },
-    "extra": [],
     "autoload": {
         "psr-4": {
             "SilverStripe\\Config\\": "src/",


### PR DESCRIPTION
Branch alias got removed, however the extra object got swap for an empty array. This might b confusing packagist because the `1.0.x-dev` branch stop resolving.

Hopefully, removing the extra key will solve this issue.