### PR TITLE
Add branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
             "SilverStripe\\Config\\": "src/",
             "SilverStripe\\Config\\Tests\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Master should be aliased as 2.0 otherwise we can't resolve dependencies when installing dependencies for framework@master.