### PR TITLE
Use stable for topsort

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "symfony/finder": "^2.8 || ^3.2 || ^4",
         "symfony/yaml": "^2.8 || ^3.2 || ^4",
-        "marcj/topsort": "^1 || ^2@dev",
+        "marcj/topsort": "^1 || ^2",
         "psr/simple-cache": "^1.0",
         "php": "^7.1 || ^8"
     },


### PR DESCRIPTION
Use stable version of topsort now that there's a stable version available https://github.com/marcj/topsort.php/releases/tag/2.0.0