### PR TITLE
FIX: Prevent unnecessary cache writes (fixes #34)

### DIFF
--- a/src/Collections/CachedConfigCollection.php
+++ b/src/Collections/CachedConfigCollection.php
@@ -141,24 +141,9 @@ class CachedConfigCollection implements ConfigCollectionInterface
             $this->building = false;
         }
 
-        // Save immediately.
-        // Note additional deferred save will occur in _destruct()
+        // Save collection in cache
         $this->cache->set(self::CACHE_KEY, $this->collection);
         return $this->collection;
-    }
-
-    /**
-     * Commits the cache
-     */
-    public function __destruct()
-    {
-        // Ensure back-end cache is updated
-        if ($this->collection) {
-            $this->cache->set(self::CACHE_KEY, $this->collection);
-
-            // Prevent double-destruct
-            $this->collection = null;
-        }
     }
 
     public function nest()

--- a/tests/Collections/CachedConfigCollectionTest.php
+++ b/tests/Collections/CachedConfigCollectionTest.php
@@ -36,12 +36,6 @@ class CachedConfigCollectionTest extends TestCase
             ->with(CachedConfigCollection::CACHE_KEY)
             ->willReturn($mockCollection);
 
-        // Set called in __destruct
-        $mockCache
-            ->expects($this->once())
-            ->method('set')
-            ->with(CachedConfigCollection::CACHE_KEY, $mockCollection);
-
         $collection = new CachedConfigCollection();
         $collection->setCollectionCreator(function () {
             $this->fail("Invalid cache miss");
@@ -51,9 +45,6 @@ class CachedConfigCollectionTest extends TestCase
         // Check
         $this->assertTrue($collection->exists('test', 'name'));
         $this->assertEquals('value', $collection->get('test', 'name'));
-
-        // Write back changes to cache
-        $collection->__destruct();
     }
 
     public function testCacheMiss()
@@ -80,9 +71,9 @@ class CachedConfigCollectionTest extends TestCase
             ->with('test', 'name', 0)
             ->willReturn(true);
 
-        // Cache will be generated, saved, and then saved again on __destruct()
+        // Cache will be generated, then saved
         $mockCache
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('set')
             ->with(CachedConfigCollection::CACHE_KEY, $mockCollection);
 
@@ -95,9 +86,6 @@ class CachedConfigCollectionTest extends TestCase
         // Check
         $this->assertTrue($collection->exists('test', 'name'));
         $this->assertEquals('value', $collection->get('test', 'name'));
-
-        // Write back changes to cache
-        $collection->__destruct();
     }
 
     public function testInfiniteLoop()


### PR DESCRIPTION
See #34.

`CachedConfigCollection` is the only `ConfigCollection` implementation that _doesn’t_ implement `MutableConfigCollection`, so IMO it’s clearly not designed to be mutable.

The nested config collection _could_ theoretically be mutable, but I think that further emphasises that we should remove `__destruct()` here because we have no idea if committing the resulting collection is desirable. If two different code paths modify the collection differently, which (if any) should be cached?

In framework when the collection is nested we don’t actually operate on `CachedConfigCollection::$collection` anyway, because we construct a new `DeltaConfigCollection` instead:

https://github.com/silverstripe/silverstripe-framework/blob/c8990e69495cbc41ab78cca767f264466eecf6cd/src/Core/Config/CoreConfigFactory.php#L52-L55

It looks to me like the only BC risk here is if someone is interacting with this package directly, _and_ nesting a cached config collection, _and_ expecting any changes on the resulting `MutableConfigCollection` to be automatically cached. IMO that’s acceptably low, but I suppose we could diff the entire config array - though I’m not sure if that would negate any performance benefits.

Unscientific benchmarks:

<details>
<summary>Before:</summary>

```
ab -n 250 -c 10 http://mysite.test/
This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking mysite.test (be patient)
Completed 100 requests
Completed 200 requests
Finished 250 requests


Server Software:        Apache/2.4.46
Server Hostname:        mysite.test
Server Port:            80

Document Path:          /
Document Length:        32700 bytes

Concurrency Level:      10
Time taken for tests:   21.361 seconds
Complete requests:      250
Failed requests:        0
Total transferred:      8342000 bytes
HTML transferred:       8175000 bytes
Requests per second:    11.70 [#/sec] (mean)
Time per request:       854.426 [ms] (mean)
Time per request:       85.443 [ms] (mean, across all concurrent requests)
Transfer rate:          381.38 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:   322  824 180.5    715    1053
Waiting:      318  819 180.5    711    1049
Total:        322  824 180.5    715    1053

Percentage of the requests served within a certain time (ms)
  50%    715
  66%    997
  75%    998
  80%    999
  90%   1008
  95%   1016
  98%   1044
  99%   1052
 100%   1053 (longest request)
```
</details>


<details>
<summary>After:</summary>

```
ab -n 250 -c 10 http://mysite.test/
This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking mysite.test (be patient)
Completed 100 requests
Completed 200 requests
Finished 250 requests


Server Software:        Apache/2.4.46
Server Hostname:        mysite.test
Server Port:            80

Document Path:          /
Document Length:        32700 bytes

Concurrency Level:      10
Time taken for tests:   20.838 seconds
Complete requests:      250
Failed requests:        0
Total transferred:      8342000 bytes
HTML transferred:       8175000 bytes
Requests per second:    12.00 [#/sec] (mean)
Time per request:       833.517 [ms] (mean)
Time per request:       83.352 [ms] (mean, across all concurrent requests)
Transfer rate:          390.94 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       0
Processing:   310  803 175.6    664    1028
Waiting:      308  801 175.6    662    1027
Total:        310  803 175.6    664    1029

Percentage of the requests served within a certain time (ms)
  50%    664
  66%    973
  75%    975
  80%    976
  90%    980
  95%    986
  98%    991
  99%   1008
 100%   1029 (longest request)
```
</details>