### PR TITLE
MNT Add codesniffer as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require-dev": {
         "silverstripe/framework": "^4.10",
         "phpunit/phpunit": "^9.5",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
A follow-up to https://github.com/silverstripe/silverstripe-config/pull/61 - adds codesniffer for the linting job.